### PR TITLE
Manifest: Track thermal-engine from LOS.

### DIFF
--- a/lineage.xml
+++ b/lineage.xml
@@ -65,6 +65,7 @@
   <project path="vendor/qcom/opensource/vibrator" name="android_vendor_qcom_opensource_vibrator" remote="lineage"/>
   <project path="vendor/qcom/opensource/wfd-commonsys" name="android_vendor_qcom_opensource_wfd-commonsys" remote="lineage"/>
   <project path="vendor/qcom/opensource/libfmjni" name="android_vendor_qcom_opensource_libfmjni" remote="lineage"/>
+  <project path="vendor/qcom/opensource/thermal-engine" name="android_vendor_qcom_opensource_thermal-engine" remote="lineage" />
 
   <!-- System Repo -->
   <project path="system/tools/dtbtool" name="android_system_tools_dtbtool" remote="lineage"/>


### PR DESCRIPTION
Needed for compilation on some devices, like the compilation of VR on OnePlus msm8998 devices throws up a thermal_client.h error the dependency for which is resolved via this repo.

Signed-off-by: Maitreya Patni <maitreyapatni30@gmail.com>